### PR TITLE
fix: text color of mark tag in the alert area

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -598,6 +598,7 @@
   .alert h5,
   .alert h6,
   .alert p,
+  .alert mark,
   .alert ul li,
   .alert ol li {
     color: #31708f;


### PR DESCRIPTION
Hi there: 
I found that text color of the `mark` tag is a little fuzzy in the alert area, and it should be keeping same as it's original color. Thanks.